### PR TITLE
Mislabelling fix

### DIFF
--- a/darknet_ros/config/tiny_yolo.yaml
+++ b/darknet_ros/config/tiny_yolo.yaml
@@ -30,7 +30,8 @@ yolo_model:
       - bench
       - bird
       - cat
-      - doghorse
+      - dog
+      - horse
       - sheep
       - cow
       - elephant

--- a/darknet_ros/config/yolo.yaml
+++ b/darknet_ros/config/yolo.yaml
@@ -30,7 +30,8 @@ yolo_model:
       - bench
       - bird
       - cat
-      - doghorse
+      - dog
+      - horse
       - sheep
       - cow
       - elephant


### PR DESCRIPTION
Fixed labellings when using the standard COCO set of labels. The config files "yolo.yaml" and "tiny_yolo.yaml" both had the separate labels "dog" and "horse" as one label "doghorse", this resulted in all labellings being shifted by one from this point onwards and meant the config file effectively only described 79 classes rather than the intended 80.