### PR TITLE
add --std=c++11 to NVCC_FLAG

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -28,6 +28,7 @@ if (CUDA_FOUND)
     -gencode arch=compute_52,code=[sm_52,compute_52]
     -gencode arch=compute_61,code=sm_61
     -gencode arch=compute_62,code=sm_62
+    --std=c++11
   )
   add_definitions(-DGPU)
 else()


### PR DESCRIPTION
Ubuntu 14.04 with gcc 4.8 and CUDA 8.0 c++11 compilation problem. 