### PR TITLE
Linking to OpenCV libraries

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -148,6 +148,7 @@ if (CUDA_FOUND)
     cublas
     curand
     ${Boost_LIBRARIES}
+    ${OpenCV_LIBRARIES}
     ${catkin_LIBRARIES}
   )
 
@@ -201,6 +202,7 @@ else()
     pthread
     stdc++
     ${Boost_LIBRARIES}
+    ${OpenCV_LIBRARIES}
     ${catkin_LIBRARIES}
   )
 


### PR DESCRIPTION
I needed to explicitly link against ${OpenCV_LIBRARIES} to get this to build under 16.04/Kinetic.