### PR TITLE
Added arg for launch file parameter files

### DIFF
--- a/darknet_ros/launch/darknet_ros.launch
+++ b/darknet_ros/launch/darknet_ros.launch
@@ -8,9 +8,13 @@
   <arg name="yolo_weights_path"          default="$(find darknet_ros)/yolo_network_config/weights"/>
   <arg name="yolo_config_path"           default="$(find darknet_ros)/yolo_network_config/cfg"/>
 
+  <!-- ROS and network parameter files -->
+  <arg name="ros_param_file"             default="$(find darknet_ros)/config/ros.yaml"/>
+  <arg name="network_param_file"         default="$(find darknet_ros)/config/yolov2-tiny.yaml"/>
+
   <!-- Load parameters -->
-  <rosparam command="load" ns="darknet_ros" file="$(find darknet_ros)/config/ros.yaml"/>
-  <rosparam command="load" ns="darknet_ros" file="$(find darknet_ros)/config/yolov2-tiny.yaml"/>
+  <rosparam command="load" ns="darknet_ros" file="$(arg ros_param_file)"/>
+  <rosparam command="load" ns="darknet_ros" file="$(arg network_param_file)"/>
 
   <!-- Start darknet and ros wrapper -->
   <node pkg="darknet_ros" type="darknet_ros" name="darknet_ros" output="screen" launch-prefix="$(arg launch_prefix)">

--- a/darknet_ros/launch/yolo_v3.launch
+++ b/darknet_ros/launch/yolo_v3.launch
@@ -1,24 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <launch>
-  <!-- Console launch prefix -->
-  <arg name="launch_prefix" default=""/>
-
-  <!-- Config and weights folder. -->
-  <arg name="yolo_weights_path"          default="$(find darknet_ros)/yolo_network_config/weights"/>
-  <arg name="yolo_config_path"           default="$(find darknet_ros)/yolo_network_config/cfg"/>
-
-  <!-- ROS and network parameter files -->
-  <arg name="ros_param_file"             default="$(find darknet_ros)/config/ros.yaml"/>
+  
+  <!-- Use YOLOv3 -->
   <arg name="network_param_file"         default="$(find darknet_ros)/config/yolov3.yaml"/>
 
 
   <!-- Include main launch file -->
   <include file="$(find darknet_ros)/launch/darknet_ros.launch">
-    <arg name="launch_prefix"         value="$(arg launch_prefix)"
-    <arg name="yolo_weights_path"     value="$(arg yolo_weights_path)"
-    <arg name="yolo_config_path"      value="$(arg yolo_config_path)"
-    <arg name="ros_param_file"        value="$(arg ros_param_file)"
     <arg name="network_param_file"    value="$(arg network_param_file)"
   </include>
 

--- a/darknet_ros/launch/yolo_v3.launch
+++ b/darknet_ros/launch/yolo_v3.launch
@@ -8,15 +8,18 @@
   <arg name="yolo_weights_path"          default="$(find darknet_ros)/yolo_network_config/weights"/>
   <arg name="yolo_config_path"           default="$(find darknet_ros)/yolo_network_config/cfg"/>
 
-  <!-- Load parameters -->
-  <rosparam command="load" ns="darknet_ros" file="$(find darknet_ros)/config/ros.yaml"/>
-  <rosparam command="load" ns="darknet_ros" file="$(find darknet_ros)/config/yolov3.yaml"/>
+  <!-- ROS and network parameter files -->
+  <arg name="ros_param_file"             default="$(find darknet_ros)/config/ros.yaml"/>
+  <arg name="network_param_file"         default="$(find darknet_ros)/config/yolov3.yaml"/>
 
-  <!-- Start darknet and ros wrapper -->
-  <node pkg="darknet_ros" type="darknet_ros" name="darknet_ros" output="screen" launch-prefix="$(arg launch_prefix)">
-    <param name="weights_path"          value="$(arg yolo_weights_path)" />
-    <param name="config_path"           value="$(arg yolo_config_path)" />
-  </node>
 
- <!--<node name="republish" type="republish" pkg="image_transport" output="screen" 	args="compressed in:=/front_camera/image_raw raw out:=/camera/image_raw" /> -->
+  <!-- Include main launch file -->
+  <include file="$(find darknet_ros)/launch/darknet_ros.launch">
+    <arg name="launch_prefix"         value="$(arg launch_prefix)"
+    <arg name="yolo_weights_path"     value="$(arg yolo_weights_path)"
+    <arg name="yolo_config_path"      value="$(arg yolo_config_path)"
+    <arg name="ros_param_file"        value="$(arg ros_param_file)"
+    <arg name="network_param_file"    value="$(arg network_param_file)"
+  </include>
+
 </launch>

--- a/darknet_ros/launch/yolo_v3.launch
+++ b/darknet_ros/launch/yolo_v3.launch
@@ -8,7 +8,7 @@
 
   <!-- Include main launch file -->
   <include file="$(find darknet_ros)/launch/darknet_ros.launch">
-    <arg name="network_param_file"    value="$(arg network_param_file)"
+    <arg name="network_param_file"    value="$(arg network_param_file)"/>
   </include>
 
 </launch>


### PR DESCRIPTION
This PR adds arguments for passing file paths into the darknet_ros.launch file, such that it can better be re-used with an include in other launch files. 
yolo_v3.launch was adapted accordingly, to minimize code duplication. 