### PR TITLE
Added GPU index parameter, correction on use of frame_id to execute detection on multiple video sources

### DIFF
--- a/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
+++ b/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
@@ -178,6 +178,7 @@ class YoloObjectDetector
   int buffId_[3];
   int buffIndex_ = 0;
   IplImage * ipl_;
+  bool ipl_valid_ = false;
   float fps_ = 0;
   float demoThresh_ = 0;
   float demoHier_ = .5;
@@ -200,6 +201,7 @@ class YoloObjectDetector
   int waitKeyDelay_;
   int fullScreen_;
   char *demoPrefix_;
+  bool drawDetections_ = true;
 
   std_msgs::Header imageHeader_;
   cv::Mat camImageCopy_;

--- a/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
+++ b/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
@@ -196,6 +196,8 @@ class YoloObjectDetector
   double demoTime_;
 
   RosBox_ *roiBoxes_;
+  std_msgs::Header roiBoxes_imageHeader_;
+
   bool viewImage_;
   bool enableConsoleOutput_;
   int waitKeyDelay_;
@@ -209,6 +211,9 @@ class YoloObjectDetector
 
   bool imageStatus_ = false;
   boost::shared_mutex mutexImageStatus_;
+
+  bool imageUpdated_ = false;
+  boost::shared_mutex mutexImageUpdated_;
 
   bool isNodeRunning_ = true;
   boost::shared_mutex mutexNodeStatus_;
@@ -244,6 +249,8 @@ class YoloObjectDetector
   IplImageWithHeader_ getIplImageWithHeader();
 
   bool getImageStatus(void);
+
+  bool getImageUpdated(bool reset = true);
 
   bool isNodeRunning(void);
 

--- a/darknet_ros/src/YoloObjectDetector.cpp
+++ b/darknet_ros/src/YoloObjectDetector.cpp
@@ -121,6 +121,13 @@ void YoloObjectDetector::init()
     strcpy(detectionNames[i], classLabels_[i].c_str());
   }
 
+  int gpu_ix = -1;
+  nodeHandle_.param("gpu_index", gpu_ix, -1);
+  if(gpu_ix >= 0){
+    ROS_INFO("GPU set %s %d", nodeHandle_.getNamespace().c_str(), gpu_ix);
+    cuda_set_device(gpu_ix);
+  }
+
   // Load network.
   setupNetwork(cfg, weights, data, thresh, detectionNames, numClasses_,
                 0, 0, 1, 0.5, 0, 0, 0, 0);


### PR DESCRIPTION
Using a single darknet_ros instance to elaborate images coming from multiple sources I found some problems and added some features:

- Added parameter **gpu_index** ranging from 0 to GPU count - 1. Default value -1 to ignore the parameter.
- If specified, call **cuda_set_device** to force the GPU used for darknet.
- Implemented some corrections to use **frame_id** from the image header to distinguish video frames coming from different video sources.
- Avoided image drawing and publishing if not requested.