### PR TITLE
/darknet_ros/found_object uses custom msg with Header for improving synchronization

### DIFF
--- a/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
+++ b/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
@@ -20,7 +20,6 @@
 // ROS
 #include <ros/ros.h>
 #include <std_msgs/Header.h>
-#include <std_msgs/Int8.h>
 #include <actionlib/server/simple_action_server.h>
 #include <sensor_msgs/image_encodings.h>
 #include <sensor_msgs/Image.h>
@@ -36,6 +35,7 @@
 // darknet_ros_msgs
 #include <darknet_ros_msgs/BoundingBoxes.h>
 #include <darknet_ros_msgs/BoundingBox.h>
+#include <darknet_ros_msgs/ObjectCount.h>
 #include <darknet_ros_msgs/CheckForObjectsAction.h>
 
 // Darknet.

--- a/darknet_ros/src/YoloObjectDetector.cpp
+++ b/darknet_ros/src/YoloObjectDetector.cpp
@@ -157,9 +157,9 @@ void YoloObjectDetector::init()
 
   imageSubscriber_ = imageTransport_.subscribe(cameraTopicName, cameraQueueSize,
                                                &YoloObjectDetector::cameraCallback, this);
-  objectPublisher_ = nodeHandle_.advertise<std_msgs::Int8>(objectDetectorTopicName,
-                                                           objectDetectorQueueSize,
-                                                           objectDetectorLatch);
+  objectPublisher_ = nodeHandle_.advertise<darknet_ros_msgs::ObjectCount>(objectDetectorTopicName,
+                                                                            objectDetectorQueueSize,
+                                                                            objectDetectorLatch);
   boundingBoxesPublisher_ = nodeHandle_.advertise<darknet_ros_msgs::BoundingBoxes>(
       boundingBoxesTopicName, boundingBoxesQueueSize, boundingBoxesLatch);
   detectionImagePublisher_ = nodeHandle_.advertise<sensor_msgs::Image>(detectionImageTopicName,
@@ -599,8 +599,10 @@ void *YoloObjectDetector::publishInThread()
       }
     }
 
-    std_msgs::Int8 msg;
-    msg.data = num;
+    darknet_ros_msgs::ObjectCount msg;
+    msg.header.stamp = ros::Time::now();
+    msg.header.frame_id = "detection";
+    msg.count = num;
     objectPublisher_.publish(msg);
 
     for (int i = 0; i < numClasses_; i++) {
@@ -629,8 +631,10 @@ void *YoloObjectDetector::publishInThread()
     boundingBoxesResults_.image_header = headerBuff_[(buffIndex_ + 1) % 3];
     boundingBoxesPublisher_.publish(boundingBoxesResults_);
   } else {
-    std_msgs::Int8 msg;
-    msg.data = 0;
+    darknet_ros_msgs::ObjectCount msg;
+    msg.header.stamp = ros::Time::now();
+    msg.header.frame_id = "detection";
+    msg.count = 0;
     objectPublisher_.publish(msg);
   }
   if (isCheckingForObjects()) {

--- a/darknet_ros_msgs/CMakeLists.txt
+++ b/darknet_ros_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ add_message_files(
   FILES
     BoundingBox.msg
     BoundingBoxes.msg
+    ObjectCount.msg
 )
 
 add_action_files(

--- a/darknet_ros_msgs/msg/ObjectCount.msg
+++ b/darknet_ros_msgs/msg/ObjectCount.msg
@@ -1,0 +1,2 @@
+Header header
+int8 count


### PR DESCRIPTION
`YOLOObjectDetector` publishes a custom message named `ObjectCount`, instead of `std_msgs::Int8` under the  `darknet_ros/found_object` topic. The former allows for the synchronization with `darknet_ros/bounding_boxes` on a single callback function using ROS message filters.

ObjectCount message prototype:
`Header header`
`int8 count`