### PR TITLE
Use encoding reported by camera driver

### DIFF
--- a/darknet_ros/src/YoloObjectDetector.cpp
+++ b/darknet_ros/src/YoloObjectDetector.cpp
@@ -162,7 +162,7 @@ void YoloObjectDetector::cameraCallback(const sensor_msgs::ImageConstPtr& msg) {
   cv_bridge::CvImagePtr cam_image;
 
   try {
-    cam_image = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+    cam_image = cv_bridge::toCvCopy(msg, msg->encoding);
   } catch (cv_bridge::Exception& e) {
     ROS_ERROR("cv_bridge exception: %s", e.what());
     return;


### PR DESCRIPTION
I use a RealSense D455, which encodes the colors in RGB8 instead of BGR8. As the reported encoding string from sensor_msgs::Image is the same used in cv_bridge, this string can just be used.

I did not put a check in to keep the camera call back fast.

The strings from include/sensor_msgs/image_encodings.h that is also accepted by cv_bridge:
    "mono8"
    "bgr8"
    "bgra8"
    "rgb8"
    "rgba8"
    "mono16"
