### PR TITLE
Implicitly convert A-channel images to 3-channel.

### DIFF
--- a/darknet_ros/src/YoloObjectDetector.cpp
+++ b/darknet_ros/src/YoloObjectDetector.cpp
@@ -162,7 +162,17 @@ void YoloObjectDetector::cameraCallback(const sensor_msgs::ImageConstPtr& msg) {
   cv_bridge::CvImagePtr cam_image;
 
   try {
-    cam_image = cv_bridge::toCvCopy(msg, msg->encoding);
+    if (msg->encoding == "mono8" || msg->encoding == "bgr8" || msg->encoding == "rgb8") {
+      cam_image = cv_bridge::toCvCopy(msg, msg->encoding);
+    } else if ( msg->encoding == "bgra8") {
+      cam_image = cv_bridge::toCvCopy(msg, "bgr8");
+    } else if ( msg->encoding == "rgba8") {
+      cam_image = cv_bridge::toCvCopy(msg, "rgb8");
+    } else if ( msg->encoding == "mono16") {
+      cam_image = cv_bridge::toCvCopy(msg, "mono8");
+    } else {
+      ROS_ERROR("Image message encoding provided is not mono8, mono16, bgr8, bgra8, rgb8 or rgba8.");
+    }
   } catch (cv_bridge::Exception& e) {
     ROS_ERROR("cv_bridge exception: %s", e.what());
     return;

--- a/darknet_ros/src/YoloObjectDetector.cpp
+++ b/darknet_ros/src/YoloObjectDetector.cpp
@@ -169,6 +169,7 @@ void YoloObjectDetector::cameraCallback(const sensor_msgs::ImageConstPtr& msg) {
     } else if ( msg->encoding == "rgba8") {
       cam_image = cv_bridge::toCvCopy(msg, "rgb8");
     } else if ( msg->encoding == "mono16") {
+      ROS_WARN_ONCE("Converting mono16 images to mono8");
       cam_image = cv_bridge::toCvCopy(msg, "mono8");
     } else {
       ROS_ERROR("Image message encoding provided is not mono8, mono16, bgr8, bgra8, rgb8 or rgba8.");


### PR DESCRIPTION
Handles all acceptable encodings used by cv_bridge. Scales mono16 to
8 bit.

This solves #330, which I inadvertently introduced with ae23d0f2fa2fd08b56d61e7aa65c851aa340ae3d